### PR TITLE
Modern Perl way of doing CORS

### DIFF
--- a/server.html
+++ b/server.html
@@ -24,6 +24,7 @@ title: enable cross-origin resource sharing
 			<li><a href="server_expressjs.html">ExpressJS</a></li>
 			<li><a href="server_iis6.html">IIS6</a></li>
 			<li><a href="server_iis7.html">IIS7</a></li>
+			<li><a href="server_perl.html">Perl</a></li>
 			<li><a href="server_php.html">PHP</a></li>
 			<li><a href="server_virtuoso.html">Virtuoso</a></li>
 		</ul>

--- a/server_cgi.html
+++ b/server_cgi.html
@@ -19,6 +19,7 @@ title: enable cross-origin resource sharing
   -content_location => 'mydata.ttl',
   -access_control_allow_origin => '*',
 );</pre>
+<p>For a more modern way of enabling CORS in Perl server scripts, see <a href="server_perl.html">the Perl page</a>.</p>
 			<p>
 				or in Python:
 			</p>

--- a/server_perl.html
+++ b/server_perl.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: enable cross-origin resource sharing
+---
+
+	<div class="container">
+		<section>
+		<h1>CORS in Perl PSGI scripts</h1>
+
+<p>The module <a
+href="https://metacpan.org/module/Plack::Middleware::CrossOrigin">Plack::Middleware::CrossOrigin</a>
+provides a complete CORS server side implementation. To allow any
+request from any location, just add this to your builder:
+</p>
+
+<pre class="code">
+    enable 'CrossOrigin', origins => '*';
+</pre>
+
+<p>This module is also available in Debian and Ubuntu as libplack-middleware-crossorigin-perl.</p>
+
+<p>For other Perl-related uses see <a href="server_cgi.html">the CGI page</a>.</p>	
+</section>
+</div>
+


### PR DESCRIPTION
Hey!

Well, frankly Real Developers[tm] haven't done stuff the CGI way since with Perl since 1996-ish, there have been at least three generations since then, and I submit a page for doing it the right way in the last generation, which is called Plack. I don't know if I should write something about what Plack is on that page too?

I could write something about how to do it with mod_perl (which is the generation after CGI but kinda died around 2005-ish), and in more modern frameworks like Catalyst, as it might be useful for some. Let me know if it is interesting. 
