### PR TITLE
Fix security issue in CORS regex

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -67,7 +67,7 @@ location / {
     #  scheme    : http or https
     #  authority : any authority ending in ".mckinsey.com"
     #  port      : nothing, or :<any_number>
-    if ($http_origin ~* (https?://.*\.mckinsey\.com(:[0-9]+)?)) {
+    if ($http_origin ~* (https?://[^/]*\.mckinsey\.com(:[0-9]+)?)) {
         set $cors "true";
     }
 


### PR DESCRIPTION
Regex should not allow for `http://adversary.com/mckinsey.com`. Fixes #74.
