### PR TITLE
Removed extra <br> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@ title: enable cross-origin resource sharing
 		</div>
 
 
-	<br><br><br><br><br>
-	<br><br><br><br><br>
+	<br><br>
 
 	</div>


### PR DESCRIPTION
It's unnecessary to have so many br tags as it creates a big white space below the row-fluid class in the mobile view. I think two are enough.
