### PR TITLE
Add End of String $ for nginx domain regex

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -67,7 +67,7 @@ location / {
     #  scheme    : http or https
     #  authority : any authority ending in ".mckinsey.com"
     #  port      : nothing, or :<any_number>
-    if ($http_origin ~* (https?://[^/]*\.mckinsey\.com(:[0-9]+)?)) {
+    if ($http_origin ~* (https?://[^/]*\.mckinsey\.com(:[0-9]+)?)$) {
         set $cors "true";
     }
 


### PR DESCRIPTION
The Regex for the domain check does not include an end of string terminator ($) so it would allow a match on additional hosts like "mckinsey.com.untrusteddomain.com" 
