### PR TITLE
serve the way w3c sez to do it 

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -36,7 +36,7 @@ location / {
 
         # be sure to add any other headers needed eg. X-APIKEY, Cache-Control ...
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST';
         add_header 'Content-Length' 0;
         add_header 'Access-Control-Max-Age' 86400; # allow caching for a day
         return 204;

--- a/server_nginx.html
+++ b/server_nginx.html
@@ -17,38 +17,37 @@ title: enable cross-origin resource sharing
 location / {
      # the dance you have to do because if's can't be nested in nginx
      if ($http_origin) {
-        set $cors "${cors}O"
+        set $cors "${cors}Origin"
      }
      if ($request_method = 'OPTIONS') {
-        set $cors "${cors}P"
+        set $cors "${cors}Options"
      }
      if ($request_method = 'POST') {
-        $cors = "${cors}S"
+        $cors = "${cors}Post"
      }
      if ($request_method = 'GET') {
-        $cors = "${cors}G"
+        $cors = "${cors}Get"
      }
 
-     # ORIGIN + OPTION request
-     if ($cors = OP) {
+     if ($cors = OriginOptions) {
         add_header 'Access-Control-Allow-Origin' $http_origin;
         # these are only needed on OPTIONS
-        add_header 'Access-Control-Allow-Credentials' 'true'; # techically only needed if doing credentials
+        add_header 'Access-Control-Allow-Credentials' 'true'; # technically only needed if doing credentials
 
-        # be sure to add any other headers needed eg. X-APIKEY, Cache-Control...
+        # be sure to add any other headers needed eg. X-APIKEY, Cache-Control ...
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
         add_header 'Content-Length' 0;
-        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Access-Control-Max-Age' 86400; # allow caching for a day
         return 204;
      }
-     # ORIGIN + GET
-     if ($cors = OG) {
+     if ($cors = OriginGet) {
         add_header 'Access-Control-Allow-Origin' $http_origin;
+        add_header 'Access-Control-Allow-Credentials' 'true'; # technically only needed if doing credentials
      }
-     # ORIGIN + POST
-     if ($cors = OS) {
+     if ($cors = OriginPost) {
         add_header 'Access-Control-Allow-Origin' $http_origin;
+        add_header 'Access-Control-Allow-Credentials' 'true'; # technically only needed if doing credentials
      }
 }
 </pre>

--- a/server_nginx.html
+++ b/server_nginx.html
@@ -6,7 +6,7 @@ title: enable cross-origin resource sharing
 <div class="container">
   <section>
     <h1>CORS on Nginx</h1>
-    
+
     <p>The following Nginx configuration enables CORS, with support
       for preflight requests.</p>
 
@@ -15,36 +15,40 @@ title: enable cross-origin resource sharing
 # Wide-open CORS config for nginx
 #
 location / {
+     # the dance you have to do because if's can't be nested in nginx
+     if ($http_origin) {
+        set $cors "${cors}O"
+     }
      if ($request_method = 'OPTIONS') {
-        add_header 'Access-Control-Allow-Origin' '*';
-        #
-        # Om nom nom cookies
-        #
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        #
-        # Custom headers and headers various browsers *should* be OK with but aren't
-        #
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        #
-        # Tell client that this pre-flight info is valid for 20 days
-        #
-        add_header 'Access-Control-Max-Age' 1728000;
-        add_header 'Content-Type' 'text/plain charset=UTF-8';
-        add_header 'Content-Length' 0;
-        return 204;
+        set $cors "${cors}P"
      }
      if ($request_method = 'POST') {
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        $cors = "${cors}S"
      }
      if ($request_method = 'GET') {
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        $cors = "${cors}G"
+     }
+
+     # ORIGIN + OPTION request
+     if ($cors = OP) {
+        add_header 'Access-Control-Allow-Origin' $http_origin;
+        # these are only needed on OPTIONS
+        add_header 'Access-Control-Allow-Credentials' 'true'; # techically only needed if doing credentials
+
+        # be sure to add any other headers needed eg. X-APIKEY, Cache-Control...
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Content-Length' 0;
+        add_header 'Access-Control-Max-Age' 1728000;
+        return 204;
+     }
+     # ORIGIN + GET
+     if ($cors = OG) {
+        add_header 'Access-Control-Allow-Origin' $http_origin;
+     }
+     # ORIGIN + POST
+     if ($cors = OS) {
+        add_header 'Access-Control-Allow-Origin' $http_origin;
      }
 }
 </pre>


### PR DESCRIPTION
The previous version of the nginx configs did not follow the recommendations of the w3c and as a result some clients would balk at the headers being served. This PR fixes issue #102. 

--timball
