### PR TITLE
Preventing whitlisting of * in CORS

### DIFF
--- a/server_expressjs.html
+++ b/server_expressjs.html
@@ -11,7 +11,7 @@ title: enable cross-origin resource sharing
 				In your <a href="http://expressjs.com/">ExpressJS</a> app on <a href="http://nodejs.org/">node.js</a>, do the following with your routes:
 			</p>
 			<pre class="code">app.use(function(req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Origin", "YOUR-DOMAIN.TLD"); // update to match the domain you will make the request from
   res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
   next();
 });


### PR DESCRIPTION
In order to prevent users from copy & pasting the code as is and opening themselves up to the whole internet, I'm suggesting the change of the Access-Control-Allow-Origin header value.