### PR TITLE
Make the IfModule statement visible

### DIFF
--- a/server_apache.html
+++ b/server_apache.html
@@ -10,9 +10,9 @@ title: enable cross-origin resource sharing
 		</p>
 		
 		<pre class="code">
-<IfModule mod_headers.c>
+&lt;IfModule mod_headers.c&gt;
   Header set Access-Control-Allow-Origin "*"
-</IfModule>
+&lt;/IfModule&gt;
     </pre>
     
     <p>To ensure that your changes are correct, it is strongly recommended that you use <pre class="code">apachectl -t</pre> to check your configuration changes for errors.  After this passes, you may need to reload Apache to make sure your changes are applied by running the command <pre>sudo service apache2 reload</pre> or <pre>apachectl -k graceful</pre>.</p>


### PR DESCRIPTION
<IfModule mod_headers.c> statement is not visible because the brackets were not encoded. Fixing that.