### PR TITLE
Remove reference to Caddy as instructions are incorrect.

### DIFF
--- a/server.html
+++ b/server.html
@@ -18,7 +18,6 @@ title: enable cross-origin resource sharing
 			<li><a href="server_aspnet.html">ASP.NET</a></li>
 			<li><a href="server_awsapigateway.html">AWS API Gateway</a></li>
 			<li><a href="https://github.com/bfenetworks/bfe/blob/develop/docs/en_us/modules/mod_cors/mod_cors.md">BFE</a></li>
-			<li><a href="server_caddy.html">Caddy</a></li>
 			<li><a href="server_cgi.html">CGI Scripts</a></li>
 			<li><a href="server_coldfusion.html">ColdFusion</a></li>
 			<li><a href="server_expressjs.html">ExpressJS</a></li>


### PR DESCRIPTION
Caddy 2 (branded as just "Caddy") has replaced Caddy 1 as of May 2020. 

enable-cors.org instructions for Caddy don't work on Caddy 2 and Caddy will not load with the directives in place as specified (i.e. it breaks the server).

To avoid causing harm by breaking people's Caddy configs, this pull removes all reference to Caddy completely. Ref #153 