### PR TITLE
Response header `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` is only required in the preflight request

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -32,14 +32,10 @@ location / {
      }
      if ($request_method = 'POST') {
         add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
      }
      if ($request_method = 'GET') {
         add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
      }
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Headers
> The HTTP Access-Control-Allow-Headers [response header](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) is used in response to a [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request)[...]

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Methods
> The HTTP Access-Control-Allow-Methods [response header](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) specifies one or more [HTTP request methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) allowed when accessing a resource in response to a [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).