### PR TITLE
Exact match for `$allow_cors` pattern matching

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -73,8 +73,8 @@ location / {
     <p>The following directive must be placed <a href="https://stackoverflow.com/questions/27358804/nginx-map-directive-why-is-it-allowed-only-on-http-level">under <code>http {}</code> level</a></p>
     <pre class="code">
 map '$request_method $http_origin' $allow_cors {
-    '~^OPTIONS https://(allow\.first\.domain|allow\.second\.domain)'    OPTIONS;
-    '~^(GET|POST) https://(allow\.first\.domain|allow\.second\.domain)' GET|POST;
+    '~^OPTIONS https://(allow\.first\.domain|allow\.second\.domain)$'    OPTIONS;
+    '~^(GET|POST) https://(allow\.first\.domain|allow\.second\.domain)$' GET|POST;
     default 0;
 }
     </pre>


### PR DESCRIPTION
Assuming `localhost:8081` is allow cors origin that we want, we would have below configuration.

```
  map '$request_method $http_origin' $allow_cors {
    '~^OPTIONS https://(localhost:8081)'    OPTIONS;
    '~^(GET|POST) https://(localhost:8081)' GET|POST;
    default 0;
  }
```


However, this will allow `localhost:80811` or `localhost:808123` and so on because regex matching is to permissive. 

This PR is fixing so that we exact matching is done for `allow_cors`